### PR TITLE
Update react-scripts to 3.1.2

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-scripts": "3.1.1",
+    "react-scripts": "3.1.2",
     "styled-components": "^4.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix for:
Definition for rule '@typescript-eslint/consistent-type-assertions' was not found